### PR TITLE
Petites corrections et ajout de l'anti pub

### DIFF
--- a/commands/allowpub.js
+++ b/commands/allowpub.js
@@ -1,0 +1,52 @@
+const discord = require('discord.js');
+exports.run = async (client, message, args, fs, config) => {
+    if (message.member.roles.some(r=>["Leader", "Administrateur", "Modérateur", "Support"].includes(r.name)))
+    {
+        const emoji = client.emojis.find(x => x.name === "prof");
+        message.react(emoji);
+        let target_user = message.guild.member(message.mentions.users.first());
+        if (!target_user)
+            message.channel.send("Argument manquant ou incorrect. Utilisation :`" + config.prefix + "allowpub <@username>`");
+        else if (target_user.id === message.author.id)
+        {
+            const emoji = client.emojis.find(x => x.name === "facepalm");
+            message.channel.send("Tu ne peux pas t'autoriser à faire des pubs toi-même " + emoji);
+        }
+        else if (target_user.highestRole.position >= message.member.highestRole.position)
+            message.channel.send("Désolé, tu ne peux pas permettre de pub à quelqu'un qui est supérieur à toi hiérarchiquement !");
+        else
+        {
+            const anti_role = ''; // to complete
+            if (target_user.roles.has(jail_role))
+            {
+
+                target_user.removeRole(antipub_role).catch(console.error);
+                let user = await global.db.User.findOne({id: target_user.id}).exec();
+                user.antipub.state = false;
+                user.antipub.date = null;
+                user.antipub.permanent = false;
+                await user.save();
+
+                message.channel.send(target_user + "  peut poster des pubs.");
+                const log = client.channels.get("461275693808877568");
+                const embed = new discord.RichEmbed()
+                    .setAuthor("Sanction annulée :", client.user.avatarURL)
+                    .setColor(10038562)
+                    .setThumbnail("https://pics.suertzz.fr/kissclipart-prisoner-png-clipart-prison-computer-icons-ea6936fe487680b1.png")
+                    .setTimestamp()
+                    .addField("Type :", "antipub")
+                    .addField("Auteur de l'annulation", message.author.username)
+                    .addField("Utilisateur :", target_user.user);
+                log.send({embed});
+            }
+            else
+                message.channel.send("L'utilisateur peut déjà poster des pubs.");
+        }
+    }
+    else
+    {
+        message.react("😡");
+        message.delete(60000);
+        return;
+    }
+}

--- a/commands/antipub.js
+++ b/commands/antipub.js
@@ -1,0 +1,66 @@
+const discord = require('discord.js');
+const moment = require('moment');
+exports.run =  async (client, message, args, fs, config) => {
+    if (message.member.roles.some(r=>["Leader", "Administrateur", "Modérateur", "Support"].includes(r.name)))
+    {
+        const emoji = client.emojis.find(x => x.name === "prof");
+        message.react(emoji);
+        let target_user = message.guild.member(message.mentions.users.first());
+        if (!target_user || (args[1].match(/^[0-9]+$/) === null))
+            message.channel.send("Argument manquant ou incorrect. Utilisation :`" + config.prefix + "antipub <@username> <duration in min> [reason]`");
+        else if (target_user.id === message.author.id)
+        {
+            const emoji = client.emojis.find(x => x.name === "facepalm");
+            message.channel.send("Tu ne peux pas te mettre le rôle antipub " + emoji);
+        }
+        else if (target_user.highestRole.position >= message.member.highestRole.position)
+            message.channel.send("Désolé " + message.author.username + " mais il ne faut pas déconner. Tu ne peux pas mettre le rôle antipub à quelqu'un qui est supérieur à toi hiérarchiquement !");
+        else
+        {
+            const anti_role = ''; // to replace
+            if (!target_user.roles.has(anti_role))
+            {
+                target_user.addRole(jail_role).catch(console.error);
+                let user = await global.db.User.findOne({id: target_user.id}).exec();
+                if (!user) {
+                    user = new global.db.User();
+                    user.id = target_user.id;
+                    user.username = target_user.user.username;
+                }
+                user.antipub.state = true;
+                if (args[1] !== "0") {
+                    user.antipub.date = moment(Date.now()).add(args[1], 'minutes');
+                } else {
+                    user.antipub.permanent = true;
+                }
+                message.channel.send(target_user + " a désormais le rôle antipub.");
+                const log = client.channels.get("461275693808877568");
+                let reason;
+                if (args[2])
+                    reason = args.slice(2).join(" ");
+                else
+                    reason = "Aucune raison spécifiée";
+                const embed = new discord.RichEmbed()
+                    .setAuthor("Sanction :", client.user.avatarURL)
+                    .setColor(10038562)
+                    .setThumbnail("https://pics.suertzz.fr/kissclipart-prisoner-png-clipart-prison-computer-icons-ea6936fe487680b1.png")
+                    .setTimestamp()
+                    .addField("Type :", "antipub")
+                    .addField("Auteur de la sanction :", message.author.username)
+                    .addField("Raison :", reason)
+                    .addField("Prend fin le :", args[1] === "0" ? "définitif" : user.antipub.date)
+                    .addField("Utilisateur :", target_user.user);
+                log.send({embed});
+                await user.save();
+            }
+            else
+                message.channel.send("L'utilisateur possède déjà le rôle antipub");
+        }
+    }
+    else
+    {
+        message.react("😡");
+        message.delete(60000);
+        return;
+    }
+};

--- a/commands/help.js
+++ b/commands/help.js
@@ -32,14 +32,24 @@ const commands = [
         roles: ['Support', 'Modérateur', 'Leader', 'Administrateur']
     },
     {
-        command: 'unmute',
-        desc: 'Rendre la parole à une personne',
+        command: 'unjail',
+        desc: 'Faire sortir une personne de prison',
         roles: ['Support', 'Modérateur', 'Leader', 'Administrateur']
     },
     {
         command: 'say',
         desc: 'Envoie un message au nom du bot',
         roles: ['Leader', 'Administrateur']
+    },
+    {
+        command: 'antipub',
+        desc: 'Mettre le rôle Anti-Pub à une personne',
+        roles: ['Support', 'Modérateur', 'Leader', 'Administrateur']
+    },
+    {
+        command: 'allowpub',
+        desc: 'Enlever le rôle Anti-Pub d\'une personne',
+        roles: ['Support', 'Modérateur', 'Leader', 'Administrateur']
     }
 ]
 

--- a/commands/jail.js
+++ b/commands/jail.js
@@ -41,7 +41,7 @@ exports.run =  async (client, message, args, fs, config) => {
                 if (args[2])
                     reason = args.slice(2).join(" ");
                 else
-                    reason = "Aucune raison spécifié";
+                    reason = "Aucune raison spécifiée";
                 const embed = new discord.RichEmbed()
                     .setAuthor("Sanction :", client.user.avatarURL)
                     .setColor(10038562)

--- a/commands/unjail.js
+++ b/commands/unjail.js
@@ -32,7 +32,7 @@ exports.run = async (client, message, args, fs, config) => {
                 message.channel.send(target_user + "  est libre.");
                 const log = client.channels.get("461275693808877568");
                 const embed = new discord.RichEmbed()
-                    .setAuthor("Sanction annulé :", client.user.avatarURL)
+                    .setAuthor("Sanction annulée :", client.user.avatarURL)
                     .setColor(10038562)
                     .setThumbnail("https://pics.suertzz.fr/kissclipart-prisoner-png-clipart-prison-computer-icons-ea6936fe487680b1.png")
                     .setTimestamp()

--- a/events/ready.js
+++ b/events/ready.js
@@ -18,10 +18,31 @@ async function jailCron(client) {
     }
 }
 
+async function antiPubCron(client) {
+    console.log("Checking if user has the Anti-Pub role..");
+    const myGuilds = client.guilds.get("269958087740358656"); // hard coded need improv
+    const antiRole = ""; // to replace
+    let lists = await global.db.User.find({}).exec();
+
+    if (lists) {
+        lists.forEach(async function(item) {
+            if (!item.antipub.permanent && (Date.now() > item.antipub.date) && item.antipub.state) {
+                console.log(item.id + " is in now free from posting pubs !");
+                item.antipub.state = false;
+                myGuilds.fetchMember(item.id).then(member => member.removeRole(myGuilds.roles.get(antiRole))).catch(console.error);
+                await item.save();
+            }
+        })
+    }
+}
+
 exports.run = (client, fs, config, args) => {
     console.log(`Ready !`);
     client.user.setActivity(config.prefix + "help");
     new CronJob('* * * * *', function() {
         jailCron(client).catch(console.error);
+    }, null, true, 'America/Los_Angeles');
+    new CronJob('* * * * *', function() {
+        antiPubCron(client).catch(console.error);
     }, null, true, 'America/Los_Angeles');
 };

--- a/src/db_schema.js
+++ b/src/db_schema.js
@@ -18,6 +18,14 @@ const userSchema = mongoose.Schema({
             type: Date,
             default: null
         }
+    },
+    antipub: {
+        state: false,
+        permanent: false,
+        date: {
+            type: Date,
+            default: null
+        }
     }
 });
 


### PR DESCRIPTION
- Correction de petites fautes de grammaire
- Ajout d'une commande permettant d'attribuer un rôle anti-pub si les règles du salon #recrutement du Discord de Mineweb ne sont pas respectées; commande basée sur le jail, donc les fichiers se ressemblent fortement. Même fonctionnement que le jail, avec crontask.

# Très important

Dans les fichiers allowpub.js, antipub.js et ready.js, il faudra compléter les variables "anti_role" (fichiers des commandes) et "antiRole" (listener ready.js) avec l'identifiant du rôle, car il n'a pas encore été créé.
